### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "websocketd"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websocketd"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["Ezra Buehler <ezra.buehler@husqvarnagroup.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Some dependencies need to be held back for our Yocto build (Rust 1.75.0)
to succeed. Most notably, we are preventing wit-bindgen from being
pulled in. Despite being an unused, optional (transitive) dependency, it
causes the build to fail as it requires "edition 2024".

Fixes: #7