### PR TITLE
Use newer and smaller version of `gardenalog`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -204,8 +204,8 @@ dependencies = [
 
 [[package]]
 name = "gardenalog"
-version = "0.1.0"
-source = "git+https://github.com/husqvarnagroup/smart-garden-gateway-crates.git#5f7906785738cfdc81c781ae8eb8e260fb7c72ca"
+version = "0.1.1"
+source = "git+https://github.com/husqvarnagroup/smart-garden-gateway-crates.git#687e6cfeb79f62735dd47e74a0fa387b7f58c8c6"
 dependencies = [
  "libc",
  "tracing",
@@ -370,15 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,7 +514,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -610,7 +601,7 @@ dependencies = [
 [[package]]
 name = "sg-ipc"
 version = "0.1.0"
-source = "git+https://github.com/husqvarnagroup/smart-garden-gateway-crates.git#5f7906785738cfdc81c781ae8eb8e260fb7c72ca"
+source = "git+https://github.com/husqvarnagroup/smart-garden-gateway-crates.git#687e6cfeb79f62735dd47e74a0fa387b7f58c8c6"
 dependencies = [
  "anyhow",
  "log",
@@ -663,12 +654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "socket-pktinfo"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,7 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -719,7 +704,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -803,7 +788,7 @@ dependencies = [
 [[package]]
 name = "tokioutil"
 version = "0.1.0"
-source = "git+https://github.com/husqvarnagroup/smart-garden-gateway-crates.git#5f7906785738cfdc81c781ae8eb8e260fb7c72ca"
+source = "git+https://github.com/husqvarnagroup/smart-garden-gateway-crates.git#687e6cfeb79f62735dd47e74a0fa387b7f58c8c6"
 dependencies = [
  "tokio",
 ]
@@ -837,18 +822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -858,15 +831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -903,12 +873,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"


### PR DESCRIPTION
The crate was optimized for smaller executable size by disabling unused features.